### PR TITLE
Add watchlist feature

### DIFF
--- a/spec/watchlist-feature.md
+++ b/spec/watchlist-feature.md
@@ -1,0 +1,239 @@
+# Watchlist Feature Spec
+
+## Overview
+
+The tMovies app lets users browse movies and TV shows, but there's no way to save favorites. The **watchlist feature** lets users bookmark movies and TV shows they want to watch later. Everything is saved in the browser — no login or account needed.
+
+---
+
+## Requirements
+
+### What users can do
+
+1. **Add to watchlist** — Click a bookmark icon on any movie/show card or detail page to save it
+2. **Remove from watchlist** — Click the same icon again to unsave it
+3. **View watchlist** — Navigate to a dedicated "Watchlist" page from the top navigation to see all saved items
+4. **Persist across sessions** — Saved items survive browser refreshes and closing/reopening the browser
+5. **Empty state** — When the watchlist is empty, show a friendly message guiding users to browse and add items
+
+### What this feature does NOT include
+
+- No user accounts or login
+- No syncing across devices or browsers
+- No sorting/filtering within the watchlist
+- No limit on how many items can be saved
+
+---
+
+## Design Approach
+
+The feature is built in **6 incremental steps**. Each step can be tested on its own before moving to the next.
+
+### Step 1: Data layer
+
+Add the data types and helper functions for reading/writing the watchlist to the browser's localStorage.
+
+**What changes:**
+- `src/types.d.ts` — Add a `IWatchlistItem` type (a movie/show plus its category)
+- `src/utils/helper.ts` — Add `saveWatchlist()` and `getWatchlist()` functions
+
+**How to test:**
+Open browser DevTools → Console, and manually call `localStorage.getItem("watchlist")` to confirm the storage key exists after the helpers are wired up.
+
+---
+
+### Step 2: Watchlist state management (Context)
+
+Create a React Context that holds the watchlist in memory and syncs it to localStorage. This follows the same pattern the app already uses for themes (`themeContext.tsx`) and modals (`globalContext.tsx`).
+
+**What changes:**
+- `src/context/watchlistContext.tsx` — New file with the WatchlistProvider and `useWatchlist()` hook
+- `src/main.tsx` — Wrap the app in the new WatchlistProvider
+
+**What the context provides:**
+| Function | What it does |
+|---|---|
+| `watchlist` | The current list of saved items |
+| `addToWatchlist(movie, category)` | Saves a movie/show |
+| `removeFromWatchlist(id)` | Removes a movie/show by ID |
+| `isInWatchlist(id)` | Returns true/false if item is saved |
+
+**How to test:**
+Use React DevTools to confirm the WatchlistProvider appears in the component tree. All other components can now access the watchlist.
+
+---
+
+### Step 3: Watchlist toggle button
+
+Create a reusable bookmark button component that can be placed on cards and detail pages.
+
+**What changes:**
+- `src/common/WatchlistButton/index.tsx` — New component
+- `src/common/index.ts` — Export the new component
+
+**Behavior:**
+- Shows a **bookmark outline** icon when the item is NOT in the watchlist
+- Shows a **filled bookmark** icon when the item IS in the watchlist
+- Clicking toggles between add/remove
+- Two visual variants: `"icon"` (just the icon, for cards) and `"full"` (icon + text like "Add to Watchlist", for the detail page)
+
+**How to test:**
+Temporarily drop the button into any page to confirm it renders, toggles state, and updates localStorage.
+
+---
+
+### Step 4: Add bookmark to movie cards
+
+Show the bookmark button on every movie/show card, visible on hover.
+
+**What changes:**
+- `src/common/MovieCard/index.tsx` — Add WatchlistButton in the top-right corner
+
+**Behavior:**
+- Appears on hover over the card
+- Clicking the bookmark does NOT navigate to the detail page (the click is intercepted)
+
+**How to test:**
+Hover over any movie card on the home page or catalog. Click the bookmark icon. Check localStorage in DevTools → Application → Local Storage to see the item saved. Click again to remove it.
+
+---
+
+### Step 5: Add bookmark to detail page
+
+Show a full "Add to Watchlist" / "Remove from Watchlist" button on the movie/show detail page.
+
+**What changes:**
+- `src/pages/Detail/index.tsx` — Add WatchlistButton below the genre tags
+
+**How to test:**
+Navigate to any movie detail page. See the button. Click to add, confirm it changes to "Remove from Watchlist." Refresh the page — the button should still show "Remove from Watchlist" (persisted).
+
+---
+
+### Step 6: Watchlist page + navigation
+
+Create the watchlist page and add a link in the navigation bar.
+
+**What changes:**
+- `src/pages/Watchlist/index.tsx` — New page component
+- `src/App.tsx` — Add `/watchlist` route
+- `src/constants/index.ts` — Add "watchlist" to the navigation links
+
+**Important: Route ordering**
+The `/watchlist` route must be placed **before** `/:category` in `App.tsx`. Otherwise, React Router would treat "watchlist" as a category name and show the Catalog page instead.
+
+```
+<Route path="/" element={<Home />} />
+<Route path="/watchlist" element={<Watchlist />} />     ← before /:category
+<Route path="/:category/:id" element={<Detail />} />
+<Route path="/:category" element={<Catalog />} />
+<Route path="*" element={<NotFound />} />
+```
+
+**Behavior:**
+- Displays all saved items as movie cards in a grid (same layout as the catalog page)
+- Each card has the bookmark button so users can remove items directly
+- Shows an empty state message when nothing is saved
+- Navigation link appears in the header and mobile sidebar automatically
+
+**How to test:**
+1. Add a few movies/shows via the bookmark buttons from Steps 4-5
+2. Click "watchlist" in the top navigation
+3. Verify all saved items appear
+4. Click a bookmark on a card to remove it — the card should disappear from the grid
+5. Remove all items — verify the empty state message appears
+
+---
+
+## Tech Stack
+
+| What | Choice | Why |
+|---|---|---|
+| Storage | `localStorage` | Simple, no backend needed, already used for themes |
+| State management | React Context | Matches existing patterns (themeContext, globalContext) |
+| Icons | `react-icons` (BsBookmark / BsBookmarkFill) | Already installed in the project |
+| Styling | Tailwind CSS | Already used everywhere in the app |
+| Routing | react-router-dom | Already used, just adding one more route |
+| Animations | Framer Motion | Already used on the detail page |
+
+**No new dependencies are needed.** Everything uses tools already in the project.
+
+---
+
+## Data Model
+
+Each saved item is stored as a JSON object in localStorage under the key `"watchlist"`:
+
+```
+Key:   "watchlist"
+Value: [
+  {
+    "id": "550",
+    "poster_path": "/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg",
+    "original_title": "Fight Club",
+    "name": "",
+    "overview": "A ticking-Loss insomnia...",
+    "backdrop_path": "/hZkgoQYus5dXo3H8T7CYV2UMrZ6.jpg",
+    "category": "movie"
+  },
+  {
+    "id": "1396",
+    "poster_path": "/ggFHVNu6YYI5L9pCfOacjizRGt.jpg",
+    "original_title": "",
+    "name": "Breaking Bad",
+    "overview": "A high school chemistry teacher...",
+    "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+    "category": "tv"
+  }
+]
+```
+
+**Why store full movie data (not just IDs)?**
+So the watchlist page loads instantly from localStorage without making API calls for each saved item.
+
+**Why include `category`?**
+The app routes are `/:category/:id` — we need to know if something is a "movie" or "tv" to link to its detail page.
+
+---
+
+## Files Summary
+
+### New files
+| File | Purpose |
+|---|---|
+| `spec/watchlist-feature.md` | This spec document |
+| `src/context/watchlistContext.tsx` | Watchlist state management |
+| `src/common/WatchlistButton/index.tsx` | Reusable bookmark toggle button |
+| `src/pages/Watchlist/index.tsx` | Watchlist page |
+
+### Modified files
+| File | Change |
+|---|---|
+| `src/types.d.ts` | Add `IWatchlistItem` interface |
+| `src/utils/helper.ts` | Add `saveWatchlist()` and `getWatchlist()` |
+| `src/main.tsx` | Wrap app with `WatchlistProvider` |
+| `src/common/index.ts` | Export `WatchlistButton` |
+| `src/common/MovieCard/index.tsx` | Add bookmark button overlay |
+| `src/pages/Detail/index.tsx` | Add "Add to Watchlist" button |
+| `src/App.tsx` | Add `/watchlist` route |
+| `src/constants/index.ts` | Add watchlist nav link |
+
+---
+
+## Testing Checklist
+
+Use this to verify the feature end-to-end after all steps are complete.
+
+- [ ] **Add from card:** Hover a movie card on the home page, click the bookmark icon. Icon fills in.
+- [ ] **Add from detail:** Open a movie detail page, click "Add to Watchlist". Button text changes to "Remove from Watchlist".
+- [ ] **Consistent state:** After adding from the detail page, go back — the card's bookmark icon is filled on hover.
+- [ ] **Watchlist page shows items:** Navigate to `/watchlist`. Added items appear as cards.
+- [ ] **Cards link correctly:** Click a movie card on the watchlist page. It opens the correct detail page (`/movie/:id` or `/tv/:id`).
+- [ ] **Remove from card:** Hover a saved movie card, click the filled bookmark. Icon goes back to outline.
+- [ ] **Remove from detail:** On a saved movie's detail page, click "Remove from Watchlist". Text changes back.
+- [ ] **Remove from watchlist page:** On the watchlist page, hover a card and click the bookmark to remove it. The card disappears.
+- [ ] **Empty state:** Remove all items. The watchlist page shows "Your watchlist is empty" with a link to browse.
+- [ ] **Persistence:** Add a few items, close the browser tab entirely, reopen the app, go to `/watchlist`. Items are still there.
+- [ ] **Navigation:** The "Watchlist" link appears in both the desktop header and mobile sidebar.
+- [ ] **TV shows work:** Add a TV show (from `/tv` catalog). Confirm it appears on the watchlist and links to `/tv/:id`.
+- [ ] **No regressions:** Browse the app normally — home page, catalog, detail pages, search. Everything still works.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
 const Catalog = lazy(() => import("./pages/Catalog"));
 const Home = lazy(() => import("./pages/Home"));
 const Detail = lazy(() => import("./pages/Detail"));
+const Watchlist = lazy(() => import("./pages/Watchlist"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const App = () => {
@@ -42,6 +43,7 @@ const App = () => {
           <Suspense fallback={<Loader />}>
             <Routes>
               <Route path="/" element={<Home />} />
+              <Route path="/watchlist" element={<Watchlist />} />
               <Route path="/:category/:id" element={<Detail />} />
               <Route path="/:category" element={<Catalog />} />
               <Route path="*" element={<NotFound />} />

--- a/src/common/MovieCard/index.tsx
+++ b/src/common/MovieCard/index.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { FaYoutube } from "react-icons/fa";
 
 import Image from "../Image";
+import WatchlistButton from "../WatchlistButton";
 import { IMovie } from "@/types";
 import { useMediaQuery } from "usehooks-ts";
 
@@ -33,6 +34,10 @@ const MovieCard = ({
           <div className="xs:text-[48px] text-[42px] text-[#ff0000] scale-[0.4] group-hover:scale-100 transition-all duration-300 ">
             <FaYoutube />
           </div>
+        </div>
+
+        <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10">
+          <WatchlistButton movie={movie} category={category as "movie" | "tv"} />
         </div>
       </Link>
 

--- a/src/common/WatchlistButton/index.tsx
+++ b/src/common/WatchlistButton/index.tsx
@@ -1,0 +1,47 @@
+import { BsBookmark, BsBookmarkFill } from "react-icons/bs";
+import { useWatchlist } from "@/context/watchlistContext";
+import type { IMovie } from "@/types";
+
+interface Props {
+  movie: IMovie;
+  category: "movie" | "tv";
+  variant?: "icon" | "full";
+}
+
+const WatchlistButton = ({ movie, category, variant = "icon" }: Props) => {
+  const { addToWatchlist, removeFromWatchlist, isInWatchlist } = useWatchlist();
+  const saved = isInWatchlist(movie.id);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (saved) {
+      removeFromWatchlist(movie.id);
+    } else {
+      addToWatchlist(movie, category);
+    }
+  };
+
+  if (variant === "full") {
+    return (
+      <button
+        onClick={handleClick}
+        className="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 bg-[#ff0000] text-white hover:-translate-y-1 shadow-md"
+      >
+        {saved ? <BsBookmarkFill /> : <BsBookmark />}
+        {saved ? "Remove from Watchlist" : "Add to Watchlist"}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className="w-8 h-8 rounded-full bg-black/60 flex items-center justify-center text-white text-sm hover:bg-black/80 transition-colors duration-200"
+    >
+      {saved ? <BsBookmarkFill className="text-yellow-400" /> : <BsBookmark />}
+    </button>
+  );
+};
+
+export default WatchlistButton;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -10,6 +10,7 @@ import { SkelatonLoader, Loader } from "./Loader";
 import Error from "./Error";
 import ThemeMenu from "./ThemeMenu";
 import Section from "./Section";
+import WatchlistButton from "./WatchlistButton";
 
 export {
   Footer,
@@ -25,4 +26,5 @@ export {
   Error,
   ThemeMenu,
   Section,
+  WatchlistButton,
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,7 @@ import { GoDeviceDesktop } from "react-icons/go";
 import { AiOutlineHome } from "react-icons/ai";
 import { TbMovie } from "react-icons/tb";
 import { MdOutlineLiveTv } from "react-icons/md";
+import { BsBookmark } from "react-icons/bs";
 
 import { ITheme, INavLink } from "../types";
 
@@ -22,6 +23,11 @@ export const navLinks: INavLink[] = [
     title: "tv series",
     path: "/tv",
     icon: MdOutlineLiveTv,
+  },
+  {
+    title: "watchlist",
+    path: "/watchlist",
+    icon: BsBookmark,
   },
 ];
 

--- a/src/context/watchlistContext.tsx
+++ b/src/context/watchlistContext.tsx
@@ -1,0 +1,54 @@
+import React, { useContext, useState, useCallback } from "react";
+import { getWatchlist, saveWatchlist } from "@/utils/helper";
+import type { IMovie, IWatchlistItem } from "@/types";
+
+const context = React.createContext({
+  watchlist: [] as IWatchlistItem[],
+  addToWatchlist: (movie: IMovie, category: "movie" | "tv") => {},
+  removeFromWatchlist: (id: string) => {},
+  isInWatchlist: (id: string) => false as boolean,
+});
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const WatchlistProvider = ({ children }: Props) => {
+  const [watchlist, setWatchlist] = useState<IWatchlistItem[]>(getWatchlist);
+
+  const addToWatchlist = useCallback((movie: IMovie, category: "movie" | "tv") => {
+    setWatchlist((prev) => {
+      if (prev.some((item) => item.id === movie.id)) return prev;
+      const next = [...prev, { ...movie, category }];
+      saveWatchlist(next);
+      return next;
+    });
+  }, []);
+
+  const removeFromWatchlist = useCallback((id: string) => {
+    setWatchlist((prev) => {
+      const next = prev.filter((item) => item.id !== id);
+      saveWatchlist(next);
+      return next;
+    });
+  }, []);
+
+  const isInWatchlist = useCallback(
+    (id: string) => watchlist.some((item) => item.id === id),
+    [watchlist]
+  );
+
+  return (
+    <context.Provider
+      value={{ watchlist, addToWatchlist, removeFromWatchlist, isInWatchlist }}
+    >
+      {children}
+    </context.Provider>
+  );
+};
+
+export default WatchlistProvider;
+
+export const useWatchlist = () => {
+  return useContext(context);
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { ApiProvider } from "@reduxjs/toolkit/query/react";
 import { tmdbApi } from "@/services/TMDB";
 import GlobalContextProvider from "@/context/globalContext";
 import ThemeProvider from "@/context/themeContext";
+import WatchlistProvider from "@/context/watchlistContext";
 import App from "./App";
 import "./index.css";
 
@@ -16,9 +17,11 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
       <ApiProvider api={tmdbApi}>
         <ThemeProvider>
           <GlobalContextProvider>
-            <LazyMotion features={domAnimation}>
-              <App />
-            </LazyMotion>
+            <WatchlistProvider>
+              <LazyMotion features={domAnimation}>
+                <App />
+              </LazyMotion>
+            </WatchlistProvider>
           </GlobalContextProvider>
         </ThemeProvider>
       </ApiProvider>

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { m } from "framer-motion";
 import { useParams } from "react-router-dom";
 
-import { Poster, Loader, Error, Section } from "@/common";
+import { Poster, Loader, Error, Section, WatchlistButton } from "@/common";
 import { Casts, Videos, Genre } from "./components";
 
 import { useGetShowQuery } from "@/services/TMDB";
@@ -108,6 +108,10 @@ const Detail = () => {
                 {!show ? "show more" : "show less"}
               </button>
             </m.p>
+
+            <m.div variants={fadeDown} className="will-change-transform motion-reduce:transform-none">
+              <WatchlistButton movie={movie} category={category as "movie" | "tv"} variant="full" />
+            </m.div>
 
             <Casts casts={credits?.cast || []} />
           </m.div>

--- a/src/pages/Watchlist/index.tsx
+++ b/src/pages/Watchlist/index.tsx
@@ -1,0 +1,46 @@
+import { Link } from "react-router-dom";
+import { BsBookmark } from "react-icons/bs";
+
+import { MovieCard } from "@/common";
+import { useWatchlist } from "@/context/watchlistContext";
+import { smallMaxWidth } from "@/styles";
+
+const Watchlist = () => {
+  const { watchlist } = useWatchlist();
+
+  return (
+    <section className={`${smallMaxWidth} pt-28 pb-8`}>
+      <h2 className="sm:text-3xl xs:text-2xl text-xl font-extrabold dark:text-secColor text-black mb-8 font-nunito">
+        My Watchlist
+      </h2>
+
+      {watchlist.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-4 py-20 dark:text-gray-400 text-gray-500">
+          <BsBookmark className="text-5xl" />
+          <p className="sm:text-lg text-base font-medium font-nunito">
+            Your watchlist is empty
+          </p>
+          <Link
+            to="/movie"
+            className="sm:py-2 xs:py-[6px] py-1 sm:px-4 xs:px-3 px-[10.75px] bg-[#ff0000] text-gray-50 rounded-full md:text-[15.25px] sm:text-[14.75px] xs:text-[14px] text-[12.75px] shadow-md hover:-translate-y-1 transition-all duration-300 font-medium font-nunito"
+          >
+            Browse Movies
+          </Link>
+        </div>
+      ) : (
+        <div className="flex flex-wrap xs:gap-4 gap-[14px] justify-center">
+          {watchlist.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-col xs:gap-4 gap-2 xs:max-w-[170px] max-w-[124px] rounded-lg lg:mb-6 md:mb-5 sm:mb-4 mb-[10px]"
+            >
+              <MovieCard movie={item} category={item.category} />
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default Watchlist;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,3 +16,7 @@ export interface IMovie {
   backdrop_path: string
 }
 
+export interface IWatchlistItem extends IMovie {
+  category: "movie" | "tv";
+}
+

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import type { IWatchlistItem } from "../types";
 
 export const getErrorMessage = (error: any) => {
   let errorMessage;
@@ -32,3 +33,14 @@ export const getTheme = () => {
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+const WATCHLIST_KEY = "tmovies-watchlist";
+
+export const getWatchlist = (): IWatchlistItem[] => {
+  const data = localStorage.getItem(WATCHLIST_KEY);
+  return data ? JSON.parse(data) : [];
+};
+
+export const saveWatchlist = (watchlist: IWatchlistItem[]) => {
+  localStorage.setItem(WATCHLIST_KEY, JSON.stringify(watchlist));
+};


### PR DESCRIPTION
## Summary
- Adds a watchlist feature that lets users save movies and TV shows to localStorage
- Includes a dedicated `/watchlist` page, bookmark toggle on movie cards (on hover) and detail pages
- Uses React Context following existing patterns (themeContext, globalContext) — no new dependencies

## Test plan
- [ ] Hover a movie card → bookmark icon appears, click to add
- [ ] Open a detail page → click "Add to Watchlist" button
- [ ] Navigate to `/watchlist` → saved items appear as cards
- [ ] Remove all items → empty state with "Browse Movies" link shown
- [ ] Close and reopen the browser → watchlist persists
- [ ] Verify TV shows link correctly to `/tv/:id`
- [ ] Browse the app normally — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)