### PR TITLE
feat: add watchlist feature with localStorage persistence

### DIFF
--- a/spec/watchlist.md
+++ b/spec/watchlist.md
@@ -1,0 +1,187 @@
+# Watchlist Feature Spec
+
+## 1. Overview
+
+Add a personal watchlist to tMovies so users can save and revisit favourite movies and TV shows. The feature requires no backend — all state is held in React Context and persisted to `localStorage`, matching the existing theme persistence pattern.
+
+---
+
+## 2. Functional Requirements
+
+| # | Requirement |
+|---|-------------|
+| FR-1 | User can add any movie or TV show to their watchlist from the **MovieCard hover overlay** |
+| FR-2 | User can add/remove items from the **Detail page** hero section |
+| FR-3 | User can remove items directly from the **Watchlist page** |
+| FR-4 | The watchlist button visually toggles between an empty icon (not saved) and a filled icon (saved) |
+| FR-5 | The nav link shows a **badge** with the current watchlist item count |
+| FR-6 | A dedicated `/watchlist` route displays all saved items as a grid |
+| FR-7 | An **empty state** message is shown when the watchlist has no items |
+| FR-8 | The watchlist **persists across page refreshes** via localStorage |
+
+---
+
+## 3. Non-Functional Requirements
+
+| # | Requirement |
+|---|-------------|
+| NFR-1 | No new npm dependencies — use only packages already installed |
+| NFR-2 | Consistent with existing Tailwind CSS utility class patterns |
+| NFR-3 | Animations use the existing `useMotion` hook / Framer Motion patterns |
+| NFR-4 | All new code is fully TypeScript typed |
+| NFR-5 | Layout is mobile-responsive (same breakpoints as existing pages) |
+
+---
+
+## 4. Tech Stack
+
+All existing — no new installs required.
+
+| Concern | Solution |
+|---------|----------|
+| State management | React Context API — mirrors `globalContext` / `themeContext` |
+| Persistence | `localStorage` — mirrors theme persistence pattern |
+| Styling | Tailwind CSS |
+| Animations | Framer Motion via existing `useMotion` hook |
+| Icons | `react-icons` |
+| Routing | React Router v6 |
+
+---
+
+## 5. Architecture / Design Approach
+
+### New Context — `watchlistContext.tsx`
+
+Mirrors `themeContext.tsx` in structure:
+
+- Holds `watchlist: MovieItem[]` in state
+- Initialises from `localStorage` on mount
+- Writes to `localStorage` on every change
+- Exposes `addToWatchlist(item)`, `removeFromWatchlist(id)`, `isInWatchlist(id)` via a `useWatchlist()` hook
+
+### Helper functions — `helper.ts`
+
+Two new pure functions added to the existing file:
+
+```ts
+getWatchlist(): MovieItem[]       // reads + parses localStorage key
+saveWatchlist(items: MovieItem[]): void  // serialises + writes to localStorage
+```
+
+### New `WatchlistButton` component
+
+- Lives in `/src/common/WatchlistButton/index.tsx`
+- Accepts `item: MovieItem` as a prop
+- Calls `useWatchlist()` internally
+- Renders a bookmark/heart icon that toggles filled/unfilled based on `isInWatchlist`
+- Exported from `/src/common/index.ts`
+
+### New `Watchlist` page
+
+- Lives in `/src/pages/Watchlist/index.tsx`
+- Reads from `useWatchlist()`
+- Renders a grid of `MovieCard` components (reuse existing component)
+- Shows empty-state UI when list is empty
+
+### Nav link
+
+- A new entry added to the nav links array in `/src/constants/index.ts`
+- Badge rendered in the nav component using `useWatchlist().watchlist.length`
+
+---
+
+## 6. Implementation Phases
+
+Each phase is independently testable before moving on.
+
+### Phase 1 — Context + localStorage
+
+**Goal:** Watchlist state initialises from and writes to `localStorage`.
+
+Files to create/modify:
+- **Create** `/src/context/watchlistContext.tsx`
+- **Modify** `/src/utils/helper.ts` — add `getWatchlist` / `saveWatchlist`
+- **Modify** `/src/main.tsx` — wrap `<App />` in `<WatchlistProvider>`
+
+**Test:** Open DevTools → Application → Local Storage. Call `addToWatchlist` from the console (or a temporary button). Refresh the page — the item should still be in state.
+
+---
+
+### Phase 2 — WatchlistButton on MovieCard
+
+**Goal:** Hovering a MovieCard shows an add/remove button that correctly toggles watchlist state.
+
+Files to create/modify:
+- **Create** `/src/common/WatchlistButton/index.tsx`
+- **Modify** `/src/common/index.ts` — export `WatchlistButton`
+- **Modify** `/src/common/MovieCard/index.tsx` — add `<WatchlistButton>` inside the hover overlay
+
+**Test:** Hover any card → click the button → icon changes to filled. Refresh → hover again → icon is still filled.
+
+---
+
+### Phase 3 — WatchlistButton on Detail page
+
+**Goal:** The Detail page hero section has an add/remove watchlist button.
+
+Files to modify:
+- **Modify** `/src/pages/Detail/index.tsx` — add `<WatchlistButton>` near the title/actions area
+
+**Test:** Navigate to any movie detail page → click the button → navigate back → hover the card → button shows as saved.
+
+---
+
+### Phase 4 — Watchlist page
+
+**Goal:** `/watchlist` displays all saved items; removing an item from this page updates the list immediately.
+
+Files to create/modify:
+- **Create** `/src/pages/Watchlist/index.tsx`
+- **Modify** `/src/App.tsx` — add `<Route path="/watchlist" element={<Watchlist />} />`
+
+**Test:** Add a few items → navigate to `/watchlist` → grid renders correctly. Remove one → it disappears immediately. Clear all → empty state is shown.
+
+---
+
+### Phase 5 — Nav link + badge count
+
+**Goal:** A "Watchlist" link appears in the nav with a live count badge.
+
+Files to modify:
+- **Modify** `/src/constants/index.ts` — add watchlist nav entry
+- **Modify** the nav component (wherever nav links are rendered) — add badge
+
+**Test:** Add 3 items → nav badge shows `3`. Remove one → badge shows `2`. Empty watchlist → badge shows `0` or is hidden.
+
+---
+
+## 7. Files to Create / Modify
+
+| Action | File | Notes |
+|--------|------|-------|
+| Create | `/src/context/watchlistContext.tsx` | Provider + `useWatchlist` hook |
+| Create | `/src/common/WatchlistButton/index.tsx` | Toggle button component |
+| Create | `/src/pages/Watchlist/index.tsx` | Watchlist grid page |
+| Modify | `/src/utils/helper.ts` | Add `getWatchlist`, `saveWatchlist` |
+| Modify | `/src/constants/index.ts` | Add watchlist nav link |
+| Modify | `/src/common/index.ts` | Export `WatchlistButton` |
+| Modify | `/src/App.tsx` | Add `/watchlist` route |
+| Modify | `/src/main.tsx` | Wrap app in `WatchlistProvider` |
+| Modify | `/src/common/MovieCard/index.tsx` | Add button to hover overlay |
+| Modify | `/src/pages/Detail/index.tsx` | Add button near hero actions |
+
+---
+
+## 8. Verification Checklist
+
+After all phases are complete, run through these checks at `http://localhost:5173`:
+
+- [ ] MovieCard hover shows watchlist button
+- [ ] Button icon toggles on click
+- [ ] State persists on refresh (check localStorage in DevTools)
+- [ ] Detail page button stays in sync with MovieCard button for the same item
+- [ ] `/watchlist` page renders saved items as a grid
+- [ ] Removing from Watchlist page updates the grid immediately
+- [ ] Empty state shows when watchlist is cleared
+- [ ] Nav badge count matches actual watchlist length
+- [ ] All above work on mobile viewport (375px wide)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ const Catalog = lazy(() => import("./pages/Catalog"));
 const Home = lazy(() => import("./pages/Home"));
 const Detail = lazy(() => import("./pages/Detail"));
 const NotFound = lazy(() => import("./pages/NotFound"));
+const Watchlist = lazy(() => import("./pages/Watchlist"));
 
 const App = () => {
   useEffect(() => {
@@ -42,6 +43,7 @@ const App = () => {
           <Suspense fallback={<Loader />}>
             <Routes>
               <Route path="/" element={<Home />} />
+              <Route path="/watchlist" element={<Watchlist />} />
               <Route path="/:category/:id" element={<Detail />} />
               <Route path="/:category" element={<Catalog />} />
               <Route path="*" element={<NotFound />} />

--- a/src/common/Header/HeaderNavItem.tsx
+++ b/src/common/Header/HeaderNavItem.tsx
@@ -6,9 +6,10 @@ interface HeaderProps {
   link: { title: string; path: string };
   isNotFoundPage: boolean;
   showBg: boolean;
+  badge?: number;
 }
 
-const HeaderNavItem = ({ link, showBg, isNotFoundPage }: HeaderProps) => {
+const HeaderNavItem = ({ link, showBg, isNotFoundPage, badge }: HeaderProps) => {
   return (
     <li>
       <NavLink
@@ -27,7 +28,14 @@ const HeaderNavItem = ({ link, showBg, isNotFoundPage }: HeaderProps) => {
         }}
         end
       >
-        {link.title}
+        <span className="flex items-center gap-1">
+          {link.title}
+          {badge ? (
+            <span className="text-[10px] bg-yellow-400 text-black rounded-full px-[5px] py-[1px] font-bold leading-none">
+              {badge}
+            </span>
+          ) : null}
+        </span>
       </NavLink>
     </li>
   );

--- a/src/common/Header/index.tsx
+++ b/src/common/Header/index.tsx
@@ -11,6 +11,7 @@ import HeaderNavItem from "./HeaderNavItem";
 
 import { useGlobalContext } from "@/context/globalContext";
 import { useTheme } from "@/context/themeContext";
+import { useWatchlist } from "@/context/watchlistContext";
 import { maxWidth, textColor } from "@/styles";
 import { navLinks } from "@/constants";
 import { THROTTLE_DELAY } from "@/utils/config";
@@ -19,6 +20,7 @@ import { cn } from "@/utils/helper";
 const Header = () => {
   const { openMenu, theme, showThemeOptions } = useTheme();
   const { setShowSidebar } = useGlobalContext();
+  const { watchlist } = useWatchlist();
 
   const [isActive, setIsActive] = useState<boolean>(false);
   const [isNotFoundPage, setIsNotFoundPage] = useState<boolean>(false);
@@ -87,6 +89,7 @@ const Header = () => {
                   link={link}
                   isNotFoundPage={isNotFoundPage}
                   showBg={isActive}
+                  badge={link.path === "/watchlist" ? watchlist.length : undefined}
                 />
               );
             })}

--- a/src/common/MovieCard/index.tsx
+++ b/src/common/MovieCard/index.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { FaYoutube } from "react-icons/fa";
 
 import Image from "../Image";
+import WatchlistButton from "../WatchlistButton";
 import { IMovie } from "@/types";
 import { useMediaQuery } from "usehooks-ts";
 
@@ -32,6 +33,9 @@ const MovieCard = ({
         <div className="absolute top-0 left-0 w-[170px]  h-full group-hover:opacity-100 opacity-0 bg-[rgba(0,0,0,0.6)] transition-all duration-300 rounded-lg flex items-center justify-center">
           <div className="xs:text-[48px] text-[42px] text-[#ff0000] scale-[0.4] group-hover:scale-100 transition-all duration-300 ">
             <FaYoutube />
+          </div>
+          <div className="absolute top-2 right-2">
+            <WatchlistButton item={movie} />
           </div>
         </div>
       </Link>

--- a/src/common/SideBar/SidebarNavItem.tsx
+++ b/src/common/SideBar/SidebarNavItem.tsx
@@ -6,9 +6,10 @@ import { cn } from "@/utils/helper";
 interface SidebarNavItemProps {
   link: INavLink;
   closeSideBar: () => void;
+  badge?: number;
 }
 
-const SidebarNavItem = ({ link, closeSideBar }: SidebarNavItemProps) => {
+const SidebarNavItem = ({ link, closeSideBar, badge }: SidebarNavItemProps) => {
   return (
     <li>
       <NavLink
@@ -20,6 +21,11 @@ const SidebarNavItem = ({ link, closeSideBar }: SidebarNavItemProps) => {
       >
         {<link.icon className="text-[18px]" />}
         <span>{link.title}</span>
+        {badge ? (
+          <span className="ml-auto text-[10px] bg-yellow-400 text-black rounded-full px-[5px] py-[1px] font-bold leading-none">
+            {badge}
+          </span>
+        ) : null}
       </NavLink>
     </li>
   );

--- a/src/common/SideBar/index.tsx
+++ b/src/common/SideBar/index.tsx
@@ -8,6 +8,7 @@ import Overlay from "../Overlay";
 
 import { useGlobalContext } from "@/context/globalContext";
 import { useTheme } from "@/context/themeContext";
+import { useWatchlist } from "@/context/watchlistContext";
 import { useOnClickOutside } from "@/hooks/useOnClickOutside";
 import { useMotion } from "@/hooks/useMotion";
 import { navLinks, themeOptions } from "@/constants";
@@ -18,6 +19,7 @@ import { cn } from "@/utils/helper";
 const SideBar: React.FC = () => {
   const { showSidebar, setShowSidebar } = useGlobalContext();
   const { theme } = useTheme();
+  const { watchlist } = useWatchlist();
   const { slideIn } = useMotion();
 
   const closeSideBar = useCallback(() => {
@@ -57,6 +59,7 @@ const SideBar: React.FC = () => {
                       link={link}
                       closeSideBar={closeSideBar}
                       key={link.title.replaceAll(" ", "")}
+                      badge={link.path === "/watchlist" ? watchlist.length : undefined}
                     />
                   );
                 })}

--- a/src/common/WatchlistButton/index.tsx
+++ b/src/common/WatchlistButton/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { BsBookmark, BsBookmarkFill } from "react-icons/bs";
+import { useWatchlist } from "@/context/watchlistContext";
+import { IMovie } from "@/types";
+
+interface Props {
+  item: IMovie;
+  className?: string;
+}
+
+const WatchlistButton = ({ item, className = "" }: Props) => {
+  const { isInWatchlist, addToWatchlist, removeFromWatchlist } = useWatchlist();
+  const saved = isInWatchlist(String(item.id));
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (saved) {
+      removeFromWatchlist(String(item.id));
+    } else {
+      addToWatchlist(item);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label={saved ? "Remove from watchlist" : "Add to watchlist"}
+      className={`text-xl hover:scale-125 active:scale-95 transition-transform duration-200 ${className}`}
+    >
+      {saved ? (
+        <BsBookmarkFill className="text-yellow-400" />
+      ) : (
+        <BsBookmark className="text-white" />
+      )}
+    </button>
+  );
+};
+
+export default WatchlistButton;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -10,6 +10,7 @@ import { SkelatonLoader, Loader } from "./Loader";
 import Error from "./Error";
 import ThemeMenu from "./ThemeMenu";
 import Section from "./Section";
+import WatchlistButton from "./WatchlistButton";
 
 export {
   Footer,
@@ -25,4 +26,5 @@ export {
   Error,
   ThemeMenu,
   Section,
+  WatchlistButton,
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,7 @@ import { GoDeviceDesktop } from "react-icons/go";
 import { AiOutlineHome } from "react-icons/ai";
 import { TbMovie } from "react-icons/tb";
 import { MdOutlineLiveTv } from "react-icons/md";
+import { BsBookmark } from "react-icons/bs";
 
 import { ITheme, INavLink } from "../types";
 
@@ -22,6 +23,11 @@ export const navLinks: INavLink[] = [
     title: "tv series",
     path: "/tv",
     icon: MdOutlineLiveTv,
+  },
+  {
+    title: "watchlist",
+    path: "/watchlist",
+    icon: BsBookmark,
   },
 ];
 

--- a/src/context/watchlistContext.tsx
+++ b/src/context/watchlistContext.tsx
@@ -1,0 +1,46 @@
+import React, { useContext, useState, useEffect } from "react";
+import { saveWatchlist, getWatchlist } from "@/utils/helper";
+import { IMovie } from "@/types";
+
+const context = React.createContext({
+  watchlist: [] as IMovie[],
+  addToWatchlist: (_item: IMovie) => {},
+  removeFromWatchlist: (_id: string) => {},
+  isInWatchlist: (_id: string) => false as boolean,
+});
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const WatchlistProvider = ({ children }: Props) => {
+  const [watchlist, setWatchlist] = useState<IMovie[]>(getWatchlist);
+
+  useEffect(() => {
+    saveWatchlist(watchlist);
+  }, [watchlist]);
+
+  const addToWatchlist = (item: IMovie) => {
+    setWatchlist((prev) => [...prev, item]);
+  };
+
+  const removeFromWatchlist = (id: string) => {
+    setWatchlist((prev) => prev.filter((item) => String(item.id) !== String(id)));
+  };
+
+  const isInWatchlist = (id: string) => {
+    return watchlist.some((item) => String(item.id) === String(id));
+  };
+
+  return (
+    <context.Provider value={{ watchlist, addToWatchlist, removeFromWatchlist, isInWatchlist }}>
+      {children}
+    </context.Provider>
+  );
+};
+
+export default WatchlistProvider;
+
+export const useWatchlist = () => {
+  return useContext(context);
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { ApiProvider } from "@reduxjs/toolkit/query/react";
 import { tmdbApi } from "@/services/TMDB";
 import GlobalContextProvider from "@/context/globalContext";
 import ThemeProvider from "@/context/themeContext";
+import WatchlistProvider from "@/context/watchlistContext";
 import App from "./App";
 import "./index.css";
 
@@ -16,9 +17,11 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
       <ApiProvider api={tmdbApi}>
         <ThemeProvider>
           <GlobalContextProvider>
-            <LazyMotion features={domAnimation}>
-              <App />
-            </LazyMotion>
+            <WatchlistProvider>
+              <LazyMotion features={domAnimation}>
+                <App />
+              </LazyMotion>
+            </WatchlistProvider>
           </GlobalContextProvider>
         </ThemeProvider>
       </ApiProvider>

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { m } from "framer-motion";
 import { useParams } from "react-router-dom";
 
-import { Poster, Loader, Error, Section } from "@/common";
+import { Poster, Loader, Error, Section, WatchlistButton } from "@/common";
 import { Casts, Videos, Genre } from "./components";
 
 import { useGetShowQuery } from "@/services/TMDB";
@@ -90,6 +90,10 @@ const Detail = () => {
                 return <Genre key={genre.id} name={genre.name} />;
               })}
             </m.ul>
+
+            <m.div variants={fadeDown} className="will-change-transform motion-reduce:transform-none">
+              <WatchlistButton item={movie} className="text-2xl" />
+            </m.div>
 
             <m.p variants={fadeDown} className={`${paragraph} will-change-transform motion-reduce:transform-none`}>
               <span>

--- a/src/pages/Watchlist/index.tsx
+++ b/src/pages/Watchlist/index.tsx
@@ -1,0 +1,65 @@
+import { m } from "framer-motion";
+import { Link } from "react-router-dom";
+
+import { MovieCard } from "@/common";
+import { useWatchlist } from "@/context/watchlistContext";
+import { useMotion } from "@/hooks/useMotion";
+import { maxWidth, mainHeading } from "@/styles";
+
+const Watchlist = () => {
+  const { watchlist } = useWatchlist();
+  const { fadeDown, staggerContainer } = useMotion();
+
+  return (
+    <section className={`${maxWidth} pt-28 pb-14 min-h-[70vh]`}>
+      <m.h1
+        variants={fadeDown}
+        initial="hidden"
+        animate="show"
+        className={`${mainHeading} mb-8`}
+      >
+        My Watchlist
+      </m.h1>
+
+      {watchlist.length === 0 ? (
+        <m.div
+          variants={fadeDown}
+          initial="hidden"
+          animate="show"
+          className="flex flex-col items-center justify-center gap-4 py-20 text-center"
+        >
+          <p className="dark:text-gray-400 text-gray-500 text-lg">
+            Your watchlist is empty.
+          </p>
+          <Link
+            to="/"
+            className="text-sm font-medium dark:text-gray-300 hover:underline"
+          >
+            Browse movies and shows →
+          </Link>
+        </m.div>
+      ) : (
+        <m.div
+          variants={staggerContainer(0.05, 0.1)}
+          initial="hidden"
+          animate="show"
+          className="flex flex-wrap xs:gap-4 gap-[14px] justify-center"
+        >
+          {watchlist.map((item) => {
+            const category = item.original_title ? "movie" : "tv";
+            return (
+              <div
+                key={item.id}
+                className="flex flex-col xs:gap-4 gap-2 xs:max-w-[170px] max-w-[124px] rounded-lg lg:mb-6 md:mb-5 sm:mb-4 mb-[10px]"
+              >
+                <MovieCard movie={item} category={category} />
+              </div>
+            );
+          })}
+        </m.div>
+      )}
+    </section>
+  );
+};
+
+export default Watchlist;

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { IMovie } from "@/types";
 
 export const getErrorMessage = (error: any) => {
   let errorMessage;
@@ -32,3 +33,12 @@ export const getTheme = () => {
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const saveWatchlist = (items: IMovie[]) => {
+  localStorage.setItem("watchlist", JSON.stringify(items));
+};
+
+export const getWatchlist = (): IMovie[] => {
+  const data = localStorage.getItem("watchlist");
+  return data ? (JSON.parse(data) as IMovie[]) : [];
+};


### PR DESCRIPTION
## Summary

- Add `WatchlistProvider` context with `addToWatchlist`, `removeFromWatchlist`, `isInWatchlist` API
- Persist watchlist to `localStorage` via `saveWatchlist`/`getWatchlist` helpers (mirrors existing theme persistence pattern)
- Add `WatchlistButton` component to `MovieCard` hover overlay and `Detail` page hero
- Add `/watchlist` route displaying saved items as a grid with an empty state
- Add watchlist nav link with live count badge in header and sidebar (desktop + mobile)
- No new dependencies — uses existing React Context, Tailwind, Framer Motion, react-icons, React Router

## Test plan

- [ ] Hover a movie card — bookmark icon appears at top-right of overlay
- [ ] Click bookmark — icon fills yellow and item is saved
- [ ] Refresh page — saved state persists (check `localStorage` key `watchlist` in DevTools)
- [ ] Navigate to a detail page — bookmark button appears below genres, stays in sync with card
- [ ] Nav shows "watchlist" link with a live count badge
- [ ] `/watchlist` page renders saved items as a grid
- [ ] Removing an item from the watchlist page updates the grid immediately
- [ ] Empty state shows when watchlist is cleared
- [ ] All of the above work on mobile (375px viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)